### PR TITLE
Configuration of GitHub repo for Azure access

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The secrets stored in each environment's Key Vault are shown in the table below.
 | `pg-admin-password` | PostgreSQL administrator password.                                |
 | `aks-kube-config`   | Base64-encoded kubeconfig for accessing the AKS cluster.          |
 | `aks-name`          | Name of the AKS cluster for this environment.                     |
+| `gh-identity-client-id` | Client ID of the Managed Identity for GitHub Actions authentication. |
+| `gh-identity-tenant-id` | Tenant ID of the Managed Identity for GitHub Actions authentication. |
 
 
 ## Remote State Initialization

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The secrets stored in each environment's Key Vault are shown in the table below.
 | ------------------- | ----------------------------------------------------------------- |
 | `rg-name`           | Name of the Azure Resource Group for this environment.            |
 | `acr-login-server`  | Login server URL of the shared Azure Container Registry (ACR).    |
+| `pg-url`            | Connection string URL for the PostgreSQL Flexible Server. Formatted as `postgresql://<username>:<password>@<fqdn>:5432` |
 | `pg-name`           | Name of the PostgreSQL server instance for this environment.      |
 | `pg-fqdn`           | Fully Qualified Domain Name (FQDN) of the PostgreSQL server.      |
 | `pg-admin-username` | PostgreSQL administrator username.                                |

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -63,5 +63,6 @@ module "identity_github" {
     { name = "Azure Kubernetes Service Cluster User Role", scope = module.kubernetes.id },
     { name = "Key Vault Secrets User", scope = module.keyvault.id },
     { name = "AcrPush", scope = data.azurerm_container_registry.shared.id },
+    { name = "Container Registry Data Importer and Data Reader", scope = data.azurerm_container_registry.shared.id },
   ]
 }

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -38,6 +38,7 @@ module "keyvault" {
   secrets = {
     "rg-name"           = var.resource_group_name
     "acr-login-server"  = data.azurerm_container_registry.shared.login_server
+    "pg-url"            = module.postgres.url
     "pg-name"           = module.postgres.name
     "pg-fqdn"           = module.postgres.fqdn
     "pg-admin-username" = module.postgres.administrator_login
@@ -57,7 +58,7 @@ module "identity_github" {
   resource_group_name = var.resource_group_name
   location            = var.location
   github_federated_identity_subjects = var.identity_github_repos
-  
+
   roles = [
     { name = "Azure Kubernetes Service Cluster User Role", scope = module.kubernetes.id },
     { name = "Key Vault Secrets User", scope = module.keyvault.id },

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -44,16 +44,20 @@ module "keyvault" {
     "pg-admin-password" = module.postgres.administrator_password
     "aks-kube-config"   = module.kubernetes.kube_config
     "aks-name"          = module.kubernetes.name
+
+    "gh-identity-client-id" = module.identity_github.client_id
+    "gh-identity-tenant-id" = module.identity_github.tenant_id
   }
 }
 
 # Managed identity for microservices (push to ACR, deploy to AKS, access Key Vault secrets)
-module "identity_microservices" {
+module "identity_github" {
   source              = "../../modules/managed-identity"
-  name                = var.identity_microservices_name
+  name                = var.identity_github_name
   resource_group_name = var.resource_group_name
   location            = var.location
-
+  github_federated_identity_subjects = var.identity_github_repos
+  
   roles = [
     { name = "Azure Kubernetes Service Cluster User Role", scope = module.kubernetes.id },
     { name = "Key Vault Secrets User", scope = module.keyvault.id },

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -22,3 +22,18 @@ output "acr_login_server" {
   description = "The login server of the shared Azure Container Registry."
   value       = data.azurerm_container_registry.shared.login_server
 }
+
+output "gh_tenant_id" {
+  description = "The GitHub OIDC tenant ID."
+  value       = module.identity_github.tenant_id
+}
+
+output "gh_client_id" {
+  description = "The GitHub OIDC client ID."
+  value       = module.identity_github.client_id
+}
+
+output "gh_subscription_id" {
+  description = "The GitHub OIDC subscription ID."
+  value       = module.identity_github.subscription_id
+}

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -21,5 +21,9 @@ aks_location     = "Switzerland North"
 # Key Vault
 keyvault_name = "rsobingusivaultdev"
 
-# Managed Identities
-identity_microservices_name = "identity-gh-microservices-dev"
+# Managed Identity for GitHub actions
+identity_github_name = "identity-gh-microservices-dev"
+identity_github_repos = [
+    "repo:Trije-bingusi/svc-courses:environment:dev"
+    # Add more repositories as needed
+]

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -24,6 +24,9 @@ keyvault_name = "rsobingusivaultdev"
 # Managed Identity for GitHub actions
 identity_github_name = "identity-gh-microservices-dev"
 identity_github_repos = [
-    "repo:Trije-bingusi/svc-courses:environment:dev"
+    "repo:Trije-bingusi/svc-courses:environment:dev",
+    "repo:Trije-bingusi/svc-notes:environment:dev",
+    "repo:Trije-bingusi/svc-users:environment:dev",
+    "repo:Trije-bingusi/svc-gateway:environment:dev"
     # Add more repositories as needed
 ]

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -76,7 +76,13 @@ variable "keyvault_name" {
 }
 
 # Managed Identities for GitHub actions
-variable "identity_microservices_name" {
-  description = "Name of the managed identity for microservices."
+variable "identity_github_name" {
+  description = "Name of the managed identity for GitHub actions, used to access relevant resources."
   type        = string
+}
+
+variable "identity_github_repos" {
+  description = "List of GitHub repositories that will be allowed to authenticate using the managed identity via OIDC. Must be in the format 'repo:<organization>/<repository>:<ref>'."
+  type        = list(string)
+  default = [ ]
 }

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -38,6 +38,7 @@ module "keyvault" {
   secrets = {
     "rg-name"           = var.resource_group_name
     "acr-login-server"  = data.azurerm_container_registry.shared.login_server
+    "pg-url"            = module.postgres.url
     "pg-name"           = module.postgres.name
     "pg-fqdn"           = module.postgres.fqdn
     "pg-admin-username" = module.postgres.administrator_login

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -63,5 +63,6 @@ module "identity_github" {
     { name = "Azure Kubernetes Service Cluster User Role", scope = module.kubernetes.id },
     { name = "Key Vault Secrets User", scope = module.keyvault.id },
     { name = "AcrPush", scope = data.azurerm_container_registry.shared.id },
+    { name = "Container Registry Data Importer and Data Reader", scope = data.azurerm_container_registry.shared.id },
   ]
 }

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -44,16 +44,20 @@ module "keyvault" {
     "pg-admin-password" = module.postgres.administrator_password
     "aks-kube-config"   = module.kubernetes.kube_config
     "aks-name"          = module.kubernetes.name
+
+    "gh-identity-client-id" = module.identity_github.client_id
+    "gh-identity-tenant-id" = module.identity_github.tenant_id
   }
 }
 
 # Managed identity for microservices (push to ACR, deploy to AKS, access Key Vault secrets)
-module "identity_microservices" {
+module "identity_github" {
   source              = "../../modules/managed-identity"
-  name                = var.identity_microservices_name
+  name                = var.identity_github_name
   resource_group_name = var.resource_group_name
   location            = var.location
-
+  github_federated_identity_subjects = var.identity_github_repos
+  
   roles = [
     { name = "Azure Kubernetes Service Cluster User Role", scope = module.kubernetes.id },
     { name = "Key Vault Secrets User", scope = module.keyvault.id },

--- a/infra/environments/prod/outputs.tf
+++ b/infra/environments/prod/outputs.tf
@@ -22,3 +22,19 @@ output "acr_login_server" {
   description = "The login server of the shared Azure Container Registry."
   value       = data.azurerm_container_registry.shared.login_server
 }
+
+output "gh_tenant_id" {
+  description = "The GitHub OIDC tenant ID."
+  value       = module.identity_github.tenant_id
+}
+
+output "gh_client_id" {
+  description = "The GitHub OIDC client ID."
+  value       = module.identity_github.client_id
+}
+
+output "gh_subscription_id" {
+  description = "The GitHub OIDC subscription ID."
+  value       = module.identity_github.subscription_id
+}
+

--- a/infra/environments/prod/terraform.tfvars
+++ b/infra/environments/prod/terraform.tfvars
@@ -23,6 +23,9 @@ keyvault_name = "rsobingusivaultprod"
 # Managed Identity for GitHub actions
 identity_github_name = "identity-gh-microservices-prod"
 identity_github_repos = [
-    "repo:Trije-bingusi/svc-courses:environment:prod"
+    "repo:Trije-bingusi/svc-courses:environment:prod",
+    "repo:Trije-bingusi/svc-notes:environment:prod",
+    "repo:Trije-bingusi/svc-users:environment:prod",
+    "repo:Trije-bingusi/svc-gateway:environment:prod"
     # Add more repositories as needed
 ]

--- a/infra/environments/prod/terraform.tfvars
+++ b/infra/environments/prod/terraform.tfvars
@@ -20,5 +20,9 @@ aks_node_vm_size = "Standard_B2pls_v2"
 # Key Vault
 keyvault_name = "rsobingusivaultprod"
 
-# Managed Identities
-identity_microservices_name = "identity-gh-microservices-prod"
+# Managed Identity for GitHub actions
+identity_github_name = "identity-gh-microservices-prod"
+identity_github_repos = [
+    "repo:Trije-bingusi/svc-courses:environment:prod"
+    # Add more repositories as needed
+]

--- a/infra/environments/prod/variables.tf
+++ b/infra/environments/prod/variables.tf
@@ -76,7 +76,13 @@ variable "keyvault_name" {
 }
 
 # Managed Identities for GitHub actions
-variable "identity_microservices_name" {
-  description = "Name of the managed identity for microservices."
+variable "identity_github_name" {
+  description = "Name of the managed identity for GitHub actions, used to access relevant resources."
   type        = string
+}
+
+variable "identity_github_repos" {
+  description = "List of GitHub repositories that will be allowed to authenticate using the managed identity via OIDC. Must be in the format 'repo:<organization>/<repository>:<ref>'."
+  type        = list(string)
+  default = [ ]
 }

--- a/infra/modules/aks/main.tf
+++ b/infra/modules/aks/main.tf
@@ -55,6 +55,7 @@ resource "azurerm_kubernetes_cluster" "this" {
 
 # Attach specified container registries
 resource "azurerm_role_assignment" "acr_attachment" {
+  count = var.attached_container_registry == null ? 0 : 1
   principal_id                     = azurerm_kubernetes_cluster.this.kubelet_identity[0].object_id
   role_definition_name             = "AcrPull"
   scope                            = var.attached_container_registry

--- a/infra/modules/managed-identity/main.tf
+++ b/infra/modules/managed-identity/main.tf
@@ -7,6 +7,8 @@ terraform {
   }
 }
 
+data "azurerm_client_config" "current" {}
+
 # Create the identity and assign the specified roles
 resource "azurerm_user_assigned_identity" "this" {
   name                = var.name

--- a/infra/modules/managed-identity/main.tf
+++ b/infra/modules/managed-identity/main.tf
@@ -24,14 +24,13 @@ resource "azurerm_role_assignment" "this" {
 
 # Optionally create GitHub OIDC federated identity credential
 resource "azurerm_federated_identity_credential" "gh" {
-  name                = "github-oidc"
+  for_each = toset(var.github_federated_identity_subjects)
+ 
+  name                = "github-oidc-${replace(each.key, "/[^A-Za-z-]/", "")}"
   resource_group_name = var.resource_group_name
   parent_id           = azurerm_user_assigned_identity.this.id
   issuer              = "https://token.actions.githubusercontent.com"
 
-  # Additional variables could be added here for more fine-grained control, e.g. specific branch only
-  subject  = "repo:${var.github_federated_identity.organization}/${var.github_federated_identity.repository}:*"
+  subject  = each.value
   audience = ["api://AzureADTokenExchange"]
-
-  count = var.github_federated_identity == null ? 0 : 1
 }

--- a/infra/modules/managed-identity/outputs.tf
+++ b/infra/modules/managed-identity/outputs.tf
@@ -7,3 +7,13 @@ output "id" {
   description = "The ID of the Managed Identity."
   value       = azurerm_user_assigned_identity.this.id
 }
+
+output "client_id" {
+  description = "Client ID of the Managed Identity."
+  value       = azurerm_user_assigned_identity.this.client_id
+}
+
+output "tenant_id" {
+  description = "Tenant ID of the Managed Identity."
+  value       = azurerm_user_assigned_identity.this.tenant_id
+}

--- a/infra/modules/managed-identity/outputs.tf
+++ b/infra/modules/managed-identity/outputs.tf
@@ -17,3 +17,8 @@ output "tenant_id" {
   description = "Tenant ID of the Managed Identity."
   value       = azurerm_user_assigned_identity.this.tenant_id
 }
+
+output "subscription_id" {
+  description = "Subscription ID of the Managed Identity. Uses the current user subscription ID."
+  value       = data.azurerm_client_config.current.subscription_id
+}

--- a/infra/modules/managed-identity/variables.tf
+++ b/infra/modules/managed-identity/variables.tf
@@ -21,11 +21,8 @@ variable "roles" {
   }))
 }
 
-variable "github_federated_identity" {
-  description = "Configuration for GitHub OIDC federated identity credential, used for GitHub Actions. If not provided, no federated identity will be created."
-  type = object({
-    organization = string
-    repository   = string
-  })
-  default = null
+variable "github_federated_identity_subjects" {
+  description = "List of subjects for GitHub OIDC federated identity credentials, used for GitHub Workflows. Should be in the format 'repo:<organization>/<repository>:<ref>'. You can use '*' as a wildcard for <ref> to allow all branches, environments, and tags."
+  type = list(string)
+  default = []
 }

--- a/infra/modules/postgres-flexible/outputs.tf
+++ b/infra/modules/postgres-flexible/outputs.tf
@@ -23,3 +23,9 @@ output "name" {
   description = "The name of the PostgreSQL Flexible Server."
   value       = azurerm_postgresql_flexible_server.this.name
 }
+
+output "url" {
+  description = "The connection string URL for the PostgreSQL Flexible Server."
+  value       = "postgresql://${azurerm_postgresql_flexible_server.this.administrator_login}:${azurerm_postgresql_flexible_server.this.administrator_password}@${azurerm_postgresql_flexible_server.this.fqdn}:5432"
+  sensitive   = true
+}

--- a/scripts/configure-github-repo.sh
+++ b/scripts/configure-github-repo.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# =====================================================================
+# Script: configure-github-repo.sh
+# Description: Creates a "dev" and "prod" environment in the specified
+#              GitHub repository by adding necessary secrets and branch
+#              protection rules.
+# Usage: ./scripts/configure-github-repo.sh <github-repo>
+# Example: ./scripts/configure-github-repo.sh Trije-bingusi/svc-notes
+# =====================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Make sure GitHub repository argument is provided
+GITHUB_REPO=${1:-}
+if [[ -z "$GITHUB_REPO" ]]; then
+    echo "Usage: $0 <github-repo>"
+    exit 1
+fi
+# Ensure `gh` CLI is available
+if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: GitHub CLI 'gh' is required but not installed."
+    exit 2
+fi
+
+# Owner/repo validation
+if [[ "$GITHUB_REPO" != */* ]]; then
+    echo "Error: <github-repo> must be in the form 'owner/repo'"
+    exit 1
+fi
+
+# Environments to create and configure
+ENVS=(dev prod)
+
+echo "Configuring GitHub repository: $GITHUB_REPO"
+
+for env in "${ENVS[@]}"; do
+    echo "\n== Environment: $env =="
+
+    # Retrieve terraform output for this environment
+    source "${SCRIPT_DIR}/utils/config.sh" "$env"
+    CLIENT_ID=$(get_terraform_output gh_client_id)
+    SUBSCRIPTION_ID=$(get_terraform_output gh_subscription_id)
+    TENANT_ID=$(get_terraform_output gh_tenant_id)
+    KEYVAULT_NAME=$(get_terraform_output keyvault_name)
+
+    # Create environment if it doesn't exist (PUT is idempotent)
+    echo "Creating environment (if missing)..."
+    gh api -X PUT "repos/${GITHUB_REPO}/environments/${env}"
+
+    # Set Azure-related secrets
+    echo "Setting environment secrets"
+    echo "$CLIENT_ID" | gh secret set AZURE_CLIENT_ID --env "$env" --repo "$GITHUB_REPO"
+    echo "$SUBSCRIPTION_ID" | gh secret set AZURE_SUBSCRIPTION_ID --env "$env" --repo "$GITHUB_REPO"
+    echo "$TENANT_ID" | gh secret set AZURE_TENANT_ID --env "$env" --repo "$GITHUB_REPO"
+
+    # Set KEYVAULT_NAME as an environment-level environment variable
+    echo "Setting environment variable KEYVAULT_NAME."
+    echo "$KEYVAULT_NAME" | gh variable set KEYVAULT_NAME --env "$env" --repo "$GITHUB_REPO"
+
+    echo "Environment '$env' configured."
+done
+
+echo "\nDone. The 'dev' and 'prod' environments exist and contain appropriate secrets and environment variables."
+
+

--- a/scripts/init-remote-backend.sh
+++ b/scripts/init-remote-backend.sh
@@ -5,6 +5,8 @@
 # settings. The output file can be specified as an argument; if not provided, it defaults
 # to 'provider.tf'.
 
+set -euo pipefail
+
 RESOURCE_GROUP_NAME=rso-dev-rg
 STORAGE_ACCOUNT_NAME=tfstatebingusi   # needs to be globally unique (across all Azure)
 STORAGE_CONTAINER_NAME=tfstate

--- a/scripts/manage-services.sh
+++ b/scripts/manage-services.sh
@@ -6,6 +6,8 @@
 # Usage: ./scripts/manage-services.sh <env> start|stop
 # =====================================================================
 
+set -euo pipefail
+
 # Validate arguments
 ENVIRONMENT=${1:-}
 ACTION=${2:-}

--- a/scripts/prepare-cluster.sh
+++ b/scripts/prepare-cluster.sh
@@ -51,9 +51,6 @@ DATABASE_BASE_URL=$(az keyvault secret show \
   --query "value" -o tsv
 )
 
-echo ${DATABASE_BASE_URL:+"Retrieved database URL from Key Vault."}
-exit 0
-
 kubectl create secret generic "$DB_SECRET_NAME" \
   --from-literal=DATABASE_BASE_URL="$DATABASE_BASE_URL" \
   --namespace "$SERVICES_NAMESPACE" \

--- a/scripts/utils/config.sh
+++ b/scripts/utils/config.sh
@@ -24,11 +24,18 @@ fi
 # Load Terraform outputs
 echo "Loading Terraform outputs from $INFRA_DIR"
 pushd "$INFRA_DIR" > /dev/null
-
 terraform init > /dev/null
-RG_NAME=$(terraform output -raw rg_name)
-AKS_NAME=$(terraform output -raw aks_name)
-PG_NAME=$(terraform output -raw pg_name)
-KEYVAULT_NAME=$(terraform output -raw keyvault_name)
-
 popd > /dev/null
+
+function get_terraform_output() {
+    local output_name=$1
+    pushd "$INFRA_DIR" > /dev/null
+    val=$(terraform output -raw "$output_name")
+    popd > /dev/null
+    echo "$val"
+}
+
+RG_NAME=$(get_terraform_output rg_name)
+AKS_NAME=$(get_terraform_output aks_name)
+PG_NAME=$(get_terraform_output pg_name)
+KEYVAULT_NAME=$(get_terraform_output keyvault_name)

--- a/scripts/utils/config.sh
+++ b/scripts/utils/config.sh
@@ -29,5 +29,6 @@ terraform init > /dev/null
 RG_NAME=$(terraform output -raw rg_name)
 AKS_NAME=$(terraform output -raw aks_name)
 PG_NAME=$(terraform output -raw pg_name)
+KEYVAULT_NAME=$(terraform output -raw keyvault_name)
 
 popd > /dev/null


### PR DESCRIPTION
Added a script `scripts/configure-github-repo.sh` which creates *dev* and *prod* environments in a specified GitHub repository and sets the secrets and environment variables needed to authenticate to Azure and access shared resources. For example, this is needed to configure CI/CD pipelines.